### PR TITLE
Obtener análisis filtrados

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,6 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-data-rest")
-    implementation("org.springframework.boot:spring-boot-starter-hateoas")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/src/main/kotlin/org/pets/history/controller/PetController.kt
+++ b/src/main/kotlin/org/pets/history/controller/PetController.kt
@@ -34,7 +34,6 @@ class PetController(
     private val petService: PetService,
     private val minioService: MinioService
 ) {
-    @GetMapping("")
     @Operation(
         summary = "Retrieves all pets",
         description = "Retrieves all registered pets",
@@ -53,6 +52,7 @@ class PetController(
             )
         ]
     )
+    @GetMapping("")
     @JsonView(View.Compact::class)
     fun getAllPets(): CollectionDTO<Pet> = CollectionDTO(petService.getAllPets())
 
@@ -101,7 +101,6 @@ class PetController(
     @JsonView(View.Compact::class)
     fun registerPet(@RequestBody @Valid pet: Pet): Pet = petService.registerPet(pet)
 
-    @GetMapping("/{petId}/medical-records")
     @Operation(
         summary = "Retrieves medical visits",
         description = "Retrieves all medical visits for a given pet id",
@@ -120,6 +119,7 @@ class PetController(
             )
         ]
     )
+    @GetMapping("/{petId}/medical-records")
     fun getMedicalVisitsForPetId(@PathVariable petId: Long): CollectionDTO<MedicalVisit> =
         CollectionDTO(petService.getMedicalVisits(petId))
 
@@ -149,8 +149,8 @@ class PetController(
     ): MedicalVisit = petService.registerMedicalVisit(petId, medicalVisitIn)
 
     @Operation(
-        summary = "Start a treatment",
-        description = "Start a treatment for a given pet id",
+        summary = "Starts a treatment",
+        description = "Starts a treatment for a given pet id",
     )
     @ApiResponses(
         value = [
@@ -173,6 +173,28 @@ class PetController(
         @RequestBody @Valid treatment: Treatment
     ): Treatment = petService.startTreatment(petId, treatment)
 
+    @Operation(
+        summary = "Uploads a profile picture",
+        description = "Uploads a profile picture for a given pet id",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "Success",
+                content = [
+                    Content(
+                        mediaType = MediaType.IMAGE_JPEG_VALUE,
+                        schema = Schema(implementation = FileDTO::class),
+                    ),
+                    Content(
+                        mediaType = MediaType.IMAGE_PNG_VALUE,
+                        schema = Schema(implementation = FileDTO::class),
+                    )
+                ]
+            )
+        ]
+    )
     @PostMapping(
         "/avatars",
         consumes = [MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.IMAGE_JPEG_VALUE, MediaType.IMAGE_PNG_VALUE]
@@ -182,6 +204,24 @@ class PetController(
         @RequestPart("avatar") avatar: MultipartFile
     ): FileDTO = FileDTO(minioService.uploadAvatar(avatar.inputStream, avatar.contentType!!))
 
+    @Operation(
+        summary = "Uploads an analysis file",
+        description = "Uploads an analysis file for a given pet id",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "Success",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_PDF_VALUE,
+                        schema = Schema(implementation = Analysis::class),
+                    )
+                ]
+            )
+        ]
+    )
     @PostMapping(
         "/{petId}/analyses",
         consumes = [MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_PDF_VALUE]
@@ -191,4 +231,27 @@ class PetController(
         @PathVariable petId: Long,
         @RequestPart("analysis") analysis: MultipartFile,
     ): Analysis = petService.attachAnalysis(petId, analysis)
+
+    @Operation(
+        summary = "Search pet analyses",
+        description = "Searches pet analyses",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Success",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = CollectionDTO::class),
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/{id}/analyses")
+    @JsonView(View.Extended::class)
+    fun searchAnalyses(@PathVariable id: Long, @RequestParam(name = "q") query: String): CollectionDTO<Analysis> =
+        CollectionDTO(petService.searchAnalyses(id, query))
 }

--- a/src/main/kotlin/org/pets/history/repository/AnalysisRepository.kt
+++ b/src/main/kotlin/org/pets/history/repository/AnalysisRepository.kt
@@ -11,7 +11,7 @@ interface AnalysisRepository : CrudRepository<Analysis, Long> {
             SELECT * 
             FROM Analysis a 
             WHERE a.pet_id = :petId 
-            AND to_tsvector('spanish', a.name || ' ' || a.text) @@ websearch_to_tsquery('spanish', :query)
+            AND TO_TSVECTOR('spanish', a.name || ' ' || a.text) @@ WEBSEARCH_TO_TSQUERY('spanish', :query)
         """,
         nativeQuery = true
     )

--- a/src/main/kotlin/org/pets/history/repository/AnalysisRepository.kt
+++ b/src/main/kotlin/org/pets/history/repository/AnalysisRepository.kt
@@ -1,6 +1,18 @@
 package org.pets.history.repository
 
 import org.pets.history.domain.Analysis
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.query.Param
 
-interface AnalysisRepository : CrudRepository<Analysis, Long>
+interface AnalysisRepository : CrudRepository<Analysis, Long> {
+    @Query(
+        value = """
+            SELECT * 
+            FROM Analysis a 
+            WHERE to_tsvector('spanish', a.name || ' ' || a.text) @@ websearch_to_tsquery('spanish', :query)
+        """,
+        nativeQuery = true
+    )
+    fun search(@Param("query") query: String): List<Analysis>
+}

--- a/src/main/kotlin/org/pets/history/repository/AnalysisRepository.kt
+++ b/src/main/kotlin/org/pets/history/repository/AnalysisRepository.kt
@@ -10,9 +10,10 @@ interface AnalysisRepository : CrudRepository<Analysis, Long> {
         value = """
             SELECT * 
             FROM Analysis a 
-            WHERE to_tsvector('spanish', a.name || ' ' || a.text) @@ websearch_to_tsquery('spanish', :query)
+            WHERE a.pet_id = :petId 
+            AND to_tsvector('spanish', a.name || ' ' || a.text) @@ websearch_to_tsquery('spanish', :query)
         """,
         nativeQuery = true
     )
-    fun search(@Param("query") query: String): List<Analysis>
+    fun search(@Param("petId") petId: Long, @Param("query") query: String): Iterable<Analysis>
 }

--- a/src/main/kotlin/org/pets/history/service/PetService.kt
+++ b/src/main/kotlin/org/pets/history/service/PetService.kt
@@ -75,4 +75,8 @@ class PetService(
         val pdfStripper = PDFTextStripper()
         return pdfStripper.getText(document)
     }
+
+    fun searchAnalyses(petId: Long, query: String): Iterable<Analysis> {
+        return analysisRepository.search(petId, query)
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,10 @@ spring:
   application:
     name: history
 
+  data:
+    rest:
+      detection-strategy: annotated
+
   datasource:
     url: jdbc:postgresql://0.0.0.0:5432/pets_history
     username: postgres
@@ -39,12 +43,14 @@ server:
 
 springdoc:
   api-docs:
-    version: OPENAPI_3_1
+    version: OPENAPI_3_0
   swagger-ui:
     display-request-duration: true
     groups-order: DESC
-    operationsSorter: method
+    operationsSorter: alpha
     use-root-path: true
+  cache:
+    disabled: true
 
 minio:
   username: miniouser

--- a/src/test/kotlin/org/pets/history/controller/PetControllerTest.kt
+++ b/src/test/kotlin/org/pets/history/controller/PetControllerTest.kt
@@ -384,8 +384,6 @@ class PetControllerTest {
         every { putObjectResult.bucket() } returns bucket
         every { putObjectResult.`object`() } returns "${pet.id}/$filename"
 
-        val analysisURL = "http://127.0.0.1:9000/$bucket/${pet.id}/$filename"
-
         mockMvc.perform(
             multipart("/pets/${pet.id}/analyses")
                 .file(multipartFile)
@@ -427,8 +425,6 @@ class PetControllerTest {
 
         every { putObjectResult.bucket() } returns bucket
         every { putObjectResult.`object`() } returns "${pet.id}/$filename"
-
-        val analysisURL = "http://127.0.0.1:9000/$bucket/${pet.id}/$filename"
 
         mockMvc.perform(
             multipart("/pets/${pet.id}/analyses")
@@ -482,5 +478,55 @@ class PetControllerTest {
         confirmVerified(minioClient)
         confirmVerified(putObjectResult)
     }
+
+// TODO: re-habilitar luego de consultar si podemos usar testcontainers para éste o todos los tests porque H2
+//  no soporta TO_TSVECTOR ni WEBSEARCH_TO_TSQUERY de PostgreSQL
+
+//    @Test
+//    fun `Given a pet id and search criteria, return a single file that matches the criteria`() {
+//        val pet = petRepository.save(anyPet())
+//
+//        val file = File("src/test/kotlin/org/pets/history/controller/dummy.pdf")
+//        val fileBytes = Files.readAllBytes(file.toPath())
+//
+//        val multipartFile = MockMultipartFile(
+//            "analysis",
+//            file.name,
+//            MediaType.APPLICATION_PDF_VALUE,
+//            fileBytes
+//        )
+//        val bucket = "analyses"
+//        val filename = UUID.randomUUID().toString()
+//
+//        every { putObjectResult.bucket() } returns bucket
+//        every { putObjectResult.`object`() } returns "${pet.id}/$filename"
+//
+//        mockMvc.perform(
+//            multipart("/pets/${pet.id}/analyses")
+//                .file(multipartFile)
+//        )
+//            .andExpect(status().isCreated)
+//
+//        verify {
+//            minioClient.bucketExists(any())
+//            minioClient.makeBucket(any())
+//            minioClient.putObject(any())
+//            putObjectResult.bucket()
+//            putObjectResult.`object`()
+//        }
+//
+//        confirmVerified(minioClient)
+//        confirmVerified(putObjectResult)
+//
+//        mockMvc.perform(
+//            get("/pets/${pet.id}/analyses?q=dummy")
+//        )
+//            .andExpect(status().isOk)
+//            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+//            .andExpect(jsonPath("$.id").isNumber)
+//            .andExpect(jsonPath("$.name").value(file.name))
+//            .andExpect(jsonPath("$.size").value(13264))
+//            .andExpect(jsonPath("$.createdAt").isNotEmpty)
+//    }
 
 }


### PR DESCRIPTION
Se puede mejorar la performance creando índices sobre `TO_TSVECTOR('spanish', a.name || ' ' || a.text)` pero para eso hay que introducir alguna herramienta de migraciones como `liquibase` o `flyway` para poder escribir los scripts SQL ya que Spring Data no soporta estas funciones de Postgres.