### PR TITLE
[POC] Obtener análisis filtrado

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,9 @@
-SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/pets_history
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=pets_history
+POSTGRES_PORT=5432
+
+SPRING_DATASOURCE_URL=jdbc:postgresql://db:${POSTGRES_PORT}/pets_history
 SPRING_SERVER_PORT=8080
 
 MINIO_USERNAME=miniouser
@@ -8,6 +13,8 @@ MINIO_PORT=9000
 MINIO_HOST=http://minio:${MINIO_PORT}
 MINIO_PUBLIC_BUCKET=public
 
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-POSTGRES_DB=pets_history
+ELASTIC_PASSWORD=elasticpassword
+ELASTIC_PORT=9200
+ELASTIC_HOST=http://elasticsearch:${ELASTIC_PORT}
+
+KIBANA_PORT=5601

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-hateoas")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.data:spring-data-elasticsearch")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0")

--- a/compose.yaml
+++ b/compose.yaml
@@ -28,7 +28,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=${POSTGRES_DB}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
       # - ./scripts/init_db.sh:/docker-entrypoint-initdb.d/01_init_db.sh
@@ -45,6 +45,45 @@ services:
       - all
       - dev
 
+  elasticsearch:
+    image: elasticsearch:8.13.3
+    restart: always
+    environment:
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - node.name=elasticsearch
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ports:
+      - "${ELASTIC_PORT}:9200"
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s http://localhost:${ELASTIC_PORT} >/dev/null || exit 1",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+    profiles:
+      - all
+      - dev
+
+  kibana:
+    image: kibana:8.13.3
+    restart: always
+    environment:
+      - ELASTICSEARCH_URL=${ELASTIC_HOST}
+    ports:
+      - "${KIBANA_PORT}:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    profiles:
+      - all
+      - dev
+
   minio:
     image: minio/minio:RELEASE.2024-04-18T19-09-19Z
     command: server --console-address ":${MINIO_WEBUI_PORT}" /data
@@ -53,8 +92,8 @@ services:
       - MINIO_ROOT_USER=${MINIO_USERNAME}
       - MINIO_ROOT_PASSWORD=${MINIO_PASSWORD}
     ports:
-      - "${MINIO_PORT}:${MINIO_PORT}"
-      - "${MINIO_WEBUI_PORT}:${MINIO_WEBUI_PORT}"
+      - "${MINIO_PORT}:9000"
+      - "${MINIO_WEBUI_PORT}:9001"
     volumes:
       - minio-data:/data
     healthcheck:
@@ -87,5 +126,6 @@ services:
       - dev
 
 volumes:
-  minio-data:
   postgres-data:
+  elasticsearch-data:
+  minio-data:

--- a/src/main/kotlin/org/pets/history/domain/IndexedAnalysis.kt
+++ b/src/main/kotlin/org/pets/history/domain/IndexedAnalysis.kt
@@ -1,0 +1,18 @@
+package org.pets.history.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.elasticsearch.annotations.Document
+import org.springframework.data.elasticsearch.annotations.Field
+import org.springframework.data.elasticsearch.annotations.FieldType
+
+@Document(indexName = "analyses")
+class IndexedAnalysis {
+    @Id
+    var id: Long? = null
+
+    @Field(type = FieldType.Long)
+    var analysisId: Long? = null
+
+    @Field(type = FieldType.Text)
+    var text: String = ""
+}

--- a/src/main/kotlin/org/pets/history/repository/IndexedAnalysisRepository.kt
+++ b/src/main/kotlin/org/pets/history/repository/IndexedAnalysisRepository.kt
@@ -1,0 +1,6 @@
+package org.pets.history.repository
+
+import org.pets.history.domain.IndexedAnalysis
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+interface IndexedAnalysisRepository : ElasticsearchRepository<IndexedAnalysis, String> {}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,3 +48,8 @@ minio:
   public_bucket: public
   analyses_bucket: analyses
   put_object_part_size: 10485760
+
+elasticsearch:
+  http:
+    enabled: true
+    port: 9200


### PR DESCRIPTION
Otra alternativa para las búsquedas que como desventaja duplica datos pero habilita búsquedas más potentes mediante `elasticsearch`, para nuestro caso de uso actual se optó por la opción built-in de Postgres parar full-text search en https://github.com/ttip-mascotas/back/pull/15.

NO MERGEAR. 